### PR TITLE
adding port variable

### DIFF
--- a/application.go
+++ b/application.go
@@ -1,9 +1,18 @@
 package main
 
 import (
+	"os"
 	"project-symi-backend/app/infrastructure"
+
+	"github.com/joho/godotenv"
 )
 
 func main() {
-	infrastructure.Router.Run()
+	err := godotenv.Load()
+	print(err)
+	port := ":" + os.Getenv("PORT")
+	if port == ":" {
+		port = ":8080"
+	}
+	infrastructure.Router.Run(port)
 }

--- a/application.go
+++ b/application.go
@@ -9,10 +9,12 @@ import (
 
 func main() {
 	err := godotenv.Load()
-	print(err)
-	port := ":" + os.Getenv("PORT")
-	if port == ":" {
-		port = ":8080"
+	if err != nil {
+		os.Exit(500)
 	}
-	infrastructure.Router.Run(port)
+	port := os.Getenv("PORT")
+	if port == "" {
+		port = "8080"
+	}
+	infrastructure.Router.Run(":" + port)
 }


### PR DESCRIPTION
Updated the main application.go to start check the environmental variables for PORT.
If none provided starting by default on :8080

AWS starts EC2 on :5000 it seems