### PR TITLE
changed the order of invitations array creation

### DIFF
--- a/app/usecase/interactor/invitation_interactor.go
+++ b/app/usecase/interactor/invitation_interactor.go
@@ -14,11 +14,11 @@ type InvitationInteractor struct {
 }
 
 func (interactor *InvitationInteractor) ChangeSeenAndFindAll() (invitations domain.LeaderInvitations, err error) {
-	err = interactor.InvitationRepository.UpdateSeenFromStatus(Pending)
+	invitations, err = interactor.InvitationRepository.FindAll()
 	if err != nil {
 		return
 	}
-	invitations, err = interactor.InvitationRepository.FindAll()
+	err = interactor.InvitationRepository.UpdateSeenFromStatus(Pending)
 	if err != nil {
 		return
 	}


### PR DESCRIPTION
Changed the order of creation for invitations array and changing their status.

Right now we create the array with the current status.
Then change the status to seen (for the next pull)